### PR TITLE
fix library-world bug

### DIFF
--- a/worlds/library.world
+++ b/worlds/library.world
@@ -5848,7 +5848,7 @@
         <collision name='collision'>
           <geometry>
             <mesh>
-              <uri>model://aws_robomaker_retail_Spotlight_01/meshes/aws_Spotlight_01_collision.DAE</uri>
+              <uri>model://aws_robomaker_retail_Spotlight_01/meshes/aws_spotlight_01_collision.DAE</uri>
               <scale>1 1 1</scale>
             </mesh>
           </geometry>
@@ -5869,7 +5869,7 @@
         <visual name='visual'>
           <geometry>
             <mesh>
-              <uri>model://aws_robomaker_retail_Spotlight_01/meshes/aws_Spotlight_01_visual.DAE</uri>
+              <uri>model://aws_robomaker_retail_Spotlight_01/meshes/aws_spotlight_01_visual.DAE</uri>
             </mesh>
           </geometry>
           <meta>


### PR DESCRIPTION
The original name "aws_Spotlight" should be "aws_spotlight", or Gazebo couldn't find correct models.